### PR TITLE
status code fix for run with xml report format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ sst.wpu
 src/testproject/testproj.db
 .tox
 .idea
+*.pyc

--- a/src/sst/__init__.py
+++ b/src/sst/__init__.py
@@ -18,7 +18,7 @@
 #
 
 
-__version__ = '0.2.8dev-2'
+__version__ = '0.2.8dev-3'
 
 DEVSERVER_PORT = 8120  # django devserver for internal acceptance tests
 

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -118,7 +118,14 @@ def runtests(test_regexps, results_directory, out,
         out.write('Test run interrupted\n')
     result.stopTestRun()
 
-    return len(result.failures) + len(result.errors)
+    if isinstance(result, testtools.testresult.MultiTestResult):
+        failures = result._results[0].failures
+        errors = result._results[0].errors
+    else:
+        failures = result.failures
+        errors = result.errors
+
+    return len(failures) + len(errors)
 
 
 def find_shared_directory(test_dir, shared_directory):

--- a/src/sst/tests/test_runtests.py
+++ b/src/sst/tests/test_runtests.py
@@ -145,6 +145,12 @@ class TestOneFail(unittest.TestCase):
     def test_one_fail(self):
         self.assertTrue(False)
 
+file: t/test_one_error.py
+import unittest
+class TestOneError(unittest.TestCase):
+    def test_one_error(self):
+        raise Exception()
+
 file: t/test_multi_fail.py
 import unittest
 class TestMultiFail(unittest.TestCase):
@@ -154,11 +160,13 @@ class TestMultiFail(unittest.TestCase):
         self.assertTrue(False)
 ''')
 
-    def run_tests(self, args):
+    def run_tests(self, args, **kwargs):
         out = StringIO()
-        failures = runtests.runtests(args, 'no results directory used', out,
-                                     browser_factory=browsers.FirefoxFactory())
-        return bool(failures)
+        failures = runtests.runtests(
+            args, '/tmp', out,
+            browser_factory=browsers.FirefoxFactory(),
+            **kwargs)
+        return failures
 
     def test_pass(self):
         self.assertEqual(0, self.run_tests(['test_all_pass$']))
@@ -166,5 +174,16 @@ class TestMultiFail(unittest.TestCase):
     def test_fail(self):
         self.assertEqual(1, self.run_tests(['test_one_fail$']))
 
+    def test_fail_for_xml(self):
+        self.assertEqual(1,
+            self.run_tests(['test_one_fail$'], report_format='xml'))
+
+    def test_error(self):
+        self.assertEqual(1, self.run_tests(['test_one_error$']))
+
     def test_multi_fail(self):
-        self.assertEqual(1, self.run_tests(['test_fail_.*']))
+        self.assertEqual(2, self.run_tests(['test_fail_.*']))
+
+    def test_multi_fail_for_xml(self):
+        self.assertEqual(2,
+            self.run_tests(['test_fail_.*'], report_format='xml'))


### PR DESCRIPTION
## Problem
sst always returns status code equal to zero when requested report format is `xml`
## Reason
`MultiTestResult` from `testtools` that is used to wrap both text and xml reports returns incorrect list of failures and errors that are used by sst when return code is calculated.
## Solution
Get errors and failures from test result wrapped in `MultiTestResult`.

@Gagnavarslan/coredata-developers  