### PR TITLE
Fix set_dropdown_value for Chrome.

### DIFF
--- a/src/sst/__init__.py
+++ b/src/sst/__init__.py
@@ -18,7 +18,7 @@
 #
 
 
-__version__ = '0.2.8dev-3'
+__version__ = '0.2.8dev-4'
 
 DEVSERVER_PORT = 8120  # django devserver for internal acceptance tests
 

--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -961,7 +961,7 @@ def set_dropdown_value(id_or_elem, text=None, value=None):
                                           text or value))
     if text and not value:
         for element in elem.find_elements_by_tag_name('option'):
-            if element.text == text:
+            if element.text.strip() == text:
                 element.click()
                 return
         msg = 'The following option could not be found in the list: %r' % text


### PR DESCRIPTION
On Chrome, `element.text` doesn't trim surrounding whitespace.

Hence, matching a dropdown option that contained leading or trailing whitespace didn't work.

cc/ @arnlaugsson 