### PR TITLE
Shows real stack trace on retry error.

### DIFF
--- a/src/sst/__init__.py
+++ b/src/sst/__init__.py
@@ -18,7 +18,7 @@
 #
 
 
-__version__ = '0.2.9.1'
+__version__ = '0.2.9.2'
 
 DEVSERVER_PORT = 8120  # django devserver for internal acceptance tests
 

--- a/src/sst/tests/test_actions.py
+++ b/src/sst/tests/test_actions.py
@@ -20,6 +20,9 @@
 from cStringIO import StringIO
 import logging
 import random
+import string
+import sys
+import traceback
 
 import mock
 import testtools
@@ -80,6 +83,20 @@ class TestRetryOnException(testtools.TestCase):
             return self.raise_exception(times=max_retries + 1)
 
         self.assertRaises(TestException, protected_raiser)
+
+    def test_retry_on_exception_fails_with_full_traceback(self):
+        max_retries = 1
+
+        @actions.retry_on_exception(TestException, retries=max_retries)
+        def protected_raiser():
+            return self.raise_exception(times=max_retries + 1)
+
+        try:
+            protected_raiser()
+        except:
+            exc_info = sys.exc_info()
+            formatted_tb = string.join(traceback.format_tb(exc_info[2]))
+            self.assertIn('raise_exception', formatted_tb)
 
     def test_retry_on_exception_fails_with_max_timeout(self):
         timeout = 0.5


### PR DESCRIPTION
Currently, stacktrace of failure does not show real stacktrace of the
failure because the last exception is reraised out of except clause.
This fixes the issue and the full stacktrace is shown.

Behaviour of this piece of code:
```
        @actions.retry_on_exception(TestException, retries=max_retries)
        def protected_raiser():
            return self.raise_exception(times=max_retries + 1)
```

Before: 
```
  File "/Users/romanko/workspace/azazo/sst/src/sst/tests/test_actions.py", line 92, in test_retry_on_exception_fails_with_full_traceback
    protected_raiser()
   File "/Users/romanko/workspace/azazo/sst/src/sst/actions.py", line 150, in inner
    raise e
```
After:
```
  File "/Users/romanko/workspace/azazo/sst/src/sst/tests/test_actions.py", line 95, in test_retry_on_exception_fails_with_full_traceback
    protected_raiser()
   File "/Users/romanko/workspace/azazo/sst/src/sst/actions.py", line 145, in inner
    return func(*args, **kwargs)
   File "/Users/romanko/workspace/azazo/sst/src/sst/tests/test_actions.py", line 92, in protected_raiser
    return self.raise_exception(times=max_retries + 1)
   File "/Users/romanko/workspace/azazo/sst/src/sst/tests/test_actions.py", line 53, in raise_exception
    raise exception()
```