### PR TITLE
Option to set logging format

### DIFF
--- a/src/sst/__init__.py
+++ b/src/sst/__init__.py
@@ -18,7 +18,7 @@
 #
 
 
-__version__ = '0.2.9.2'
+__version__ = '0.2.9.3'
 
 DEVSERVER_PORT = 8120  # django devserver for internal acceptance tests
 

--- a/src/sst/command.py
+++ b/src/sst/command.py
@@ -119,6 +119,9 @@ def get_common_options():
     parser.add_option('--log', '--log-level', dest='log_level',
                       default='DEBUG',
                       help=('Set log level for SST logger'))
+    parser.add_option('--log-format', dest='log_format',
+            default='    %(asctime)s %(threadName)s %(levelname)s:%(name)s:%(message)s',
+            help=('Set log format for SST logger'))
     parser.add_option('-c', '--concurrency', dest='concurrency',
                       default=1, type='int',
                       help='concurrency (number of procs)')
@@ -176,7 +179,7 @@ def get_opts(get_options, args=None):
               cmd_opts.browser_type, browsers.browser_factories.keys())
         sys.exit(1)
 
-    logging.basicConfig(format='    %(levelname)s:%(name)s:%(message)s')
+    logging.basicConfig(format=cmd_opts.log_format)
     logger = logging.getLogger('SST')
 
     numeric_level = getattr(logging, cmd_opts.log_level.upper(), logging.DEBUG)


### PR DESCRIPTION
Default option is changed to include time and thread name.
Thread name is useful as client can set test name in it so that instead
of:

```
    DEBUG:SST:Writing to textfield u'id_password' with text 'selenium'
    DEBUG:SST:Check text wrote correctly
    DEBUG:SST:Clicking element u'login-main-form'
    DEBUG:SST:Waiting for 'get_element'
    INFO:SST:Step 5: Tester2 verifies that both tasks appear under his home task tab.
```

log looks like:
```
    2018-05-08 20:49:07,499 test_home_tasks_tab DEBUG:SST:Writing to textfield u'id_password' with text 'selenium'
    2018-05-08 20:49:07,602 test_home_tasks_tab DEBUG:SST:Check text wrote correctly
    2018-05-08 20:49:07,617 test_home_tasks_tab DEBUG:SST:Clicking element u'login-main-form'
    2018-05-08 20:49:08,909 test_home_tasks_tab DEBUG:SST:Waiting for 'get_element'
    2018-05-08 20:49:08,957 test_home_tasks_tab INFO:SST:Step 5: Tester2 verifies that both tasks appear under his home task tab.
```

This is especially helpful when multiple tests are run concurrently and log to console.