### PR TITLE
Better logging and error message for `get_element`.

### DIFF
--- a/src/sst/__init__.py
+++ b/src/sst/__init__.py
@@ -18,7 +18,7 @@
 #
 
 
-__version__ = '0.2.9.3'
+__version__ = '0.2.9.4'
 
 DEVSERVER_PORT = 8120  # django devserver for internal acceptance tests
 

--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -804,21 +804,31 @@ def get_wait_timeout():
     return _TIMEOUT
 
 
-def _get_name(obj):
+def _get_name(obj, *args, **kwargs):
     try:
-        return obj.__name__
+        name = obj.__name__
     except:
-        return repr(obj)
+        name = repr(obj)
+
+    if not args and not kwargs:
+        return name
+    else:
+        params = []
+        if args:
+            params.append(str(args)[1:-1])
+        if kwargs:
+            params.append(str(kwargs)[1:-1])
+        return '%s(%s)' % (name, ', '.join(params))
 
 
 def _wait_for(condition, refresh_page, timeout, poll, *args, **kwargs):
-    logger.debug('Waiting for %r' % _get_name(condition))
+    msg = _get_name(condition, *args, **kwargs)
+    logger.debug('Waiting for %r' % msg)
     # Disable logging levels equal to or lower than INFO.
     logging.disable(logging.INFO)
     result = None
     try:
         max_time = time.time() + timeout
-        msg = _get_name(condition)
         while True:
             #refresh the page if requested
             if refresh_page:


### PR DESCRIPTION
With this PR we got this:
```
2018-05-09 11:35:22,282 test_home_tasks_tab DEBUG:SST:Waiting for
"get_element('tag': 'body')"
```

instead of
```
2018-05-09 11:35:22,282 test_home_tasks_tab DEBUG:SST:Waiting for
"get_element"
```