### PR TITLE
Support for browser console/errors log retrieval

### DIFF
--- a/src/sst/__init__.py
+++ b/src/sst/__init__.py
@@ -18,7 +18,7 @@
 #
 
 
-__version__ = '0.2.9.5'
+__version__ = '0.2.9.6'
 
 DEVSERVER_PORT = 8120  # django devserver for internal acceptance tests
 

--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -1791,6 +1791,6 @@ def get_element_source(id_or_elem):
     elem = _get_elem(id_or_elem)
     return elem.get_attribute('innerHTML')
 
+
 def get_browser_log():
-    import ipdb; ipdb.set_trace()
     return _test.browser.get_log('browser')

--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -1790,3 +1790,7 @@ def get_element_source(id_or_elem):
     """
     elem = _get_elem(id_or_elem)
     return elem.get_attribute('innerHTML')
+
+def get_browser_log():
+    import ipdb; ipdb.set_trace()
+    return _test.browser.get_log('browser')

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -26,6 +26,7 @@ import time
 from selenium import webdriver
 from selenium.common import exceptions as selenium_exceptions
 from selenium.webdriver.common import utils
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.firefox import (
     firefox_binary,
     webdriver as ff_webdriver,
@@ -84,7 +85,6 @@ class ChromeFactory(BrowserFactory):
     webdriver_class = webdriver.Chrome
 
     def browser(self):
-        from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
         desired = DesiredCapabilities.CHROME
         desired['loggingPrefs'] = { 'browser':'ALL' }
         return self.webdriver_class(self.profile, capabilities=desired)
@@ -100,7 +100,7 @@ class IeFactory(BrowserFactory):
 class PhantomJSFactory(BrowserFactory):
 
     webdriver_class = webdriver.PhantomJS
-    
+
     def browser(self):
         return self.webdriver_class(service_args=['--ignore-ssl-errors=true'])
 
@@ -215,7 +215,6 @@ class FirefoxFactory(BrowserFactory):
         self.profile = profile
 
     def browser(self):
-        from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
         desired = DesiredCapabilities.FIREFOX
         desired['loggingPrefs'] = { 'browser':'ALL' }
         return self.webdriver_class(self.profile, capabilities=desired)

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -83,6 +83,12 @@ class ChromeFactory(BrowserFactory):
 
     webdriver_class = webdriver.Chrome
 
+    def browser(self):
+        from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+        desired = DesiredCapabilities.CHROME
+        desired['loggingPrefs'] = { 'browser':'ALL' }
+        return self.webdriver_class(self.profile, capabilities=desired)
+
 
 # MISSINGTEST: Exercise this class (requires windows) -- vila 2013-04-11
 class IeFactory(BrowserFactory):
@@ -209,7 +215,10 @@ class FirefoxFactory(BrowserFactory):
         self.profile = profile
 
     def browser(self):
-        return self.webdriver_class(self.profile)
+        from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+        desired = DesiredCapabilities.FIREFOX
+        desired['loggingPrefs'] = { 'browser':'ALL' }
+        return self.webdriver_class(self.profile, capabilities=desired)
 
 
 # MISSINGTEST: Exercise this class -- vila 2013-04-11


### PR DESCRIPTION
https://azazo.tpondemand.com/entity/17553-store-browser-console-log-when-selenium

This enables browser log capturing.

## Testing

I've tested this for Firefox (see `Limitations` below), Chrome and Remote driver.

## Limitations
In Firefox only js errors and exceptions are shown. Output to `console` can't be retrieved due to [limitation](https://github.com/mozilla/geckodriver/issues/284) of firefox driver.