### PR TITLE
Specify list of ssl ciphers for Phantomjs

### DIFF
--- a/src/sst/__init__.py
+++ b/src/sst/__init__.py
@@ -18,7 +18,7 @@
 #
 
 
-__version__ = '0.2.9.6'
+__version__ = '0.2.9.7'
 
 DEVSERVER_PORT = 8120  # django devserver for internal acceptance tests
 

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -106,7 +106,6 @@ class PhantomJSFactory(BrowserFactory):
             '--ignore-ssl-errors=true',
             '--ssl-protocol=any',
             '--web-security=false',
-            '--debug=true',
             '--ssl-ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384'
         ]
         return self.webdriver_class(service_args=service_args)

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -102,7 +102,14 @@ class PhantomJSFactory(BrowserFactory):
     webdriver_class = webdriver.PhantomJS
 
     def browser(self):
-        return self.webdriver_class(service_args=['--ignore-ssl-errors=true'])
+        service_args = [
+            '--ignore-ssl-errors=true',
+            '--ssl-protocol=any',
+            '--web-security=false',
+            '--debug=true',
+            '--ssl-ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384'
+        ]
+        return self.webdriver_class(service_args=service_args)
 
 
 # MISSINGTEST: Exercise this class -- vila 2013-04-11


### PR DESCRIPTION
The list of supported ciphers in Nginx (proxy) config does not match with the one used by phantomjs by default. The solution might be to provide this list explicitly.
Tested on test02-dev.